### PR TITLE
Support session injection in ItemRepository and pagination improvements

### DIFF
--- a/app/repositories/item_repository.py
+++ b/app/repositories/item_repository.py
@@ -12,7 +12,12 @@ from sqlalchemy import select, func, text
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.models.entities import Item, MockItem, _items_storage, get_next_id
-from app.models.schemas import ItemCreate, ItemUpdate, PaginationParams
+from app.models.schemas import (
+    ItemCreate,
+    ItemUpdate,
+    PaginationParams,
+    PaginatedResponse,
+)
 from app.models.database import db_manager
 
 logger = logging.getLogger(__name__)
@@ -48,17 +53,31 @@ class BaseRepository(ABC):
 
 
 class ItemRepository(BaseRepository):
-    """Repository for Item entities with enterprise-grade error handling."""
-    
-    def __init__(self):
+    """Repository for :class:`Item` entities.
+
+    The original implementation always created its own database session which
+    made it impossible to reuse an existing session in calling code.  The test
+    suite (and typical repository usage) expects a session to be injectable so
+    that multiple operations can share the same transaction.  Without accepting
+    a session parameter, instantiating ``ItemRepository`` with a session raised
+    ``TypeError``.  This class now accepts an optional SQLAlchemy session and
+    uses it for all database operations when provided.
+    """
+
+    def __init__(self, session=None):
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.use_mock = os.getenv("USE_MOCK_DB", "false").lower() == "true"
+        self.session = session
     
+    async def get(self, item_id: int) -> Optional[Item]:
+        """Alias for :meth:`get_by_id` for backwards compatibility."""
+        return await self.get_by_id(item_id)
+
     async def get_by_id(self, item_id: int) -> Optional[Item]:
         """Get item by ID with error handling."""
         try:
             self.logger.debug(f"Fetching item with id: {item_id}")
-            
+
             if self.use_mock:
                 # Mock implementation
                 item = _items_storage.get(item_id)
@@ -67,19 +86,25 @@ class ItemRepository(BaseRepository):
                 else:
                     self.logger.debug(f"Item with id {item_id} not found")
                 return item
-            
-            # Real PostgreSQL implementation
-            async with db_manager.get_session() as session:
-                result = await session.execute(
+
+            if self.session:
+                result = await self.session.execute(
                     select(Item).where(Item.id == item_id)
                 )
                 item = result.scalar_one_or_none()
-                if item:
-                    self.logger.debug(f"Found item: {item}")
-                else:
-                    self.logger.debug(f"Item with id {item_id} not found")
-                return item
-                
+            else:
+                async with db_manager.get_session() as session:
+                    result = await session.execute(
+                        select(Item).where(Item.id == item_id)
+                    )
+                    item = result.scalar_one_or_none()
+
+            if item:
+                self.logger.debug(f"Found item: {item}")
+            else:
+                self.logger.debug(f"Item with id {item_id} not found")
+            return item
+
         except SQLAlchemyError as e:
             self.logger.error(f"Database error fetching item {item_id}: {e}")
             raise
@@ -87,46 +112,63 @@ class ItemRepository(BaseRepository):
             self.logger.error(f"Error fetching item {item_id}: {e}")
             raise
     
-    async def get_all(self, pagination: Optional[PaginationParams] = None) -> tuple[List[Item], int]:
+    async def get_all(
+        self, pagination: Optional[PaginationParams] = None
+    ) -> PaginatedResponse:
         """Get all items with pagination."""
         try:
+            pagination = pagination or PaginationParams()
             self.logger.debug("Fetching all items")
-            
+
             if self.use_mock:
                 # Mock implementation
                 all_items = list(_items_storage.values())
                 total = len(all_items)
-                
+
                 # Sort by creation time (newest first)
                 all_items.sort(key=lambda x: x.created_at, reverse=True)
-                
-                if pagination:
-                    start = pagination.offset
-                    end = start + pagination.limit
-                    items = all_items[start:end]
-                else:
-                    items = all_items
-                
+
+                start = pagination.offset
+                end = start + pagination.limit
+                items = all_items[start:end]
+
                 self.logger.debug(f"Found {len(items)} items (total: {total})")
-                return items, total
-            
-            # Real PostgreSQL implementation
-            async with db_manager.get_session() as session:
+                return PaginatedResponse.create(
+                    items=items,
+                    total=total,
+                    page=pagination.page,
+                    limit=pagination.limit,
+                )
+
+            if self.session:
                 # Get total count
-                count_result = await session.execute(select(func.count(Item.id)))
+                count_result = await self.session.execute(select(func.count(Item.id)))
                 total = count_result.scalar()
-                
+
                 # Get paginated results
                 query = select(Item).order_by(Item.created_at.desc())
-                if pagination:
-                    query = query.offset(pagination.offset).limit(pagination.limit)
-                
-                result = await session.execute(query)
+                query = query.offset(pagination.offset).limit(pagination.limit)
+                result = await self.session.execute(query)
                 items = result.scalars().all()
-                
-                self.logger.debug(f"Found {len(items)} items (total: {total})")
-                return list(items), total
-            
+            else:
+                async with db_manager.get_session() as session:
+                    count_result = await session.execute(select(func.count(Item.id)))
+                    total = count_result.scalar()
+
+                    query = select(Item).order_by(Item.created_at.desc())
+                    query = query.offset(pagination.offset).limit(pagination.limit)
+
+                    result = await session.execute(query)
+                    items = result.scalars().all()
+
+            self.logger.debug(f"Found {len(items)} items (total: {total})")
+            return PaginatedResponse.create(
+                items=list(items),
+                total=total,
+                page=pagination.page,
+                limit=pagination.limit,
+            )
+
         except SQLAlchemyError as e:
             self.logger.error(f"Database error fetching items: {e}")
             raise
@@ -146,22 +188,29 @@ class ItemRepository(BaseRepository):
                     id=item_id,
                     name=item_data.name,
                     price=item_data.price,
-                    is_offer=item_data.is_offer
+                    is_offer=item_data.is_offer,
                 )
                 _items_storage[item_id] = item
-                
+
                 self.logger.info(f"Created item with id: {item_id}")
                 return item
-            
-            # Real PostgreSQL implementation
-            async with db_manager.get_session() as session:
+
+            if self.session:
                 db_item = Item(**item_data.model_dump())
-                session.add(db_item)
-                await session.commit()
-                await session.refresh(db_item)
-                
+                self.session.add(db_item)
+                await self.session.commit()
+                await self.session.refresh(db_item)
                 self.logger.info(f"Created item with id: {db_item.id}")
                 return db_item
+            else:
+                async with db_manager.get_session() as session:
+                    db_item = Item(**item_data.model_dump())
+                    session.add(db_item)
+                    await session.commit()
+                    await session.refresh(db_item)
+
+                    self.logger.info(f"Created item with id: {db_item.id}")
+                    return db_item
             
         except SQLAlchemyError as e:
             self.logger.error(f"Database error creating item: {e}")
@@ -181,37 +230,55 @@ class ItemRepository(BaseRepository):
                 if not item:
                     self.logger.debug(f"Item {item_id} not found for update")
                     return None
-                
+
                 update_data = item_data.model_dump(exclude_unset=True)
                 for field, value in update_data.items():
                     setattr(item, field, value)
-                
+
                 item.updated_at = datetime.now()
-                
+
                 self.logger.info(f"Updated item {item_id}")
                 return item
-            
-            # Real PostgreSQL implementation
-            async with db_manager.get_session() as session:
-                result = await session.execute(
+
+            if self.session:
+                result = await self.session.execute(
                     select(Item).where(Item.id == item_id)
                 )
                 db_item = result.scalar_one_or_none()
-                
                 if not db_item:
                     self.logger.debug(f"Item {item_id} not found for update")
                     return None
-                
+
                 update_data = item_data.model_dump(exclude_unset=True)
                 for field, value in update_data.items():
                     setattr(db_item, field, value)
-                
+
                 db_item.updated_at = func.now()
-                await session.commit()
-                await session.refresh(db_item)
-                
+                await self.session.commit()
+                await self.session.refresh(db_item)
                 self.logger.info(f"Updated item {item_id}")
                 return db_item
+            else:
+                async with db_manager.get_session() as session:
+                    result = await session.execute(
+                        select(Item).where(Item.id == item_id)
+                    )
+                    db_item = result.scalar_one_or_none()
+
+                    if not db_item:
+                        self.logger.debug(f"Item {item_id} not found for update")
+                        return None
+
+                    update_data = item_data.model_dump(exclude_unset=True)
+                    for field, value in update_data.items():
+                        setattr(db_item, field, value)
+
+                    db_item.updated_at = func.now()
+                    await session.commit()
+                    await session.refresh(db_item)
+
+                    self.logger.info(f"Updated item {item_id}")
+                    return db_item
             
         except SQLAlchemyError as e:
             self.logger.error(f"Database error updating item {item_id}: {e}")
@@ -234,23 +301,36 @@ class ItemRepository(BaseRepository):
                 else:
                     self.logger.debug(f"Item {item_id} not found for deletion")
                     return False
-            
-            # Real PostgreSQL implementation
-            async with db_manager.get_session() as session:
-                result = await session.execute(
+
+            if self.session:
+                result = await self.session.execute(
                     select(Item).where(Item.id == item_id)
                 )
                 db_item = result.scalar_one_or_none()
-                
                 if not db_item:
                     self.logger.debug(f"Item {item_id} not found for deletion")
                     return False
-                
-                await session.delete(db_item)
-                await session.commit()
-                
+
+                await self.session.delete(db_item)
+                await self.session.commit()
                 self.logger.info(f"Deleted item {item_id}")
                 return True
+            else:
+                async with db_manager.get_session() as session:
+                    result = await session.execute(
+                        select(Item).where(Item.id == item_id)
+                    )
+                    db_item = result.scalar_one_or_none()
+
+                    if not db_item:
+                        self.logger.debug(f"Item {item_id} not found for deletion")
+                        return False
+
+                    await session.delete(db_item)
+                    await session.commit()
+
+                    self.logger.info(f"Deleted item {item_id}")
+                    return True
                 
         except SQLAlchemyError as e:
             self.logger.error(f"Database error deleting item {item_id}: {e}")
@@ -259,61 +339,85 @@ class ItemRepository(BaseRepository):
             self.logger.error(f"Error deleting item {item_id}: {e}")
             raise
     
-    async def search(self, query: str, pagination: Optional[PaginationParams] = None) -> tuple[List[Item], int]:
+    async def search(
+        self, query: str, pagination: Optional[PaginationParams] = None
+    ) -> PaginatedResponse:
         """Search items by name."""
         try:
+            pagination = pagination or PaginationParams()
             self.logger.debug(f"Searching items with query: {query}")
-            
+
             if self.use_mock:
                 # Mock implementation
                 all_items = list(_items_storage.values())
                 filtered_items = [
-                    item for item in all_items 
-                    if query.lower() in item.name.lower()
+                    item for item in all_items if query.lower() in item.name.lower()
                 ]
-                
+
                 total = len(filtered_items)
-                
+
                 # Sort by relevance and creation time
                 filtered_items.sort(key=lambda x: x.created_at, reverse=True)
-                
-                if pagination:
-                    start = pagination.offset
-                    end = start + pagination.limit
-                    items = filtered_items[start:end]
-                else:
-                    items = filtered_items
-                
-                self.logger.debug(f"Found {len(items)} items matching query (total: {total})")
-                return items, total
-            
-            # Real PostgreSQL implementation using full-text search
-            async with db_manager.get_session() as session:
-                # Use PostgreSQL's full-text search for better performance
-                search_query = f"%{query.lower()}%"
-                
-                # Get total count
-                count_result = await session.execute(
+
+                start = pagination.offset
+                end = start + pagination.limit
+                items = filtered_items[start:end]
+
+                self.logger.debug(
+                    f"Found {len(items)} items matching query (total: {total})"
+                )
+                return PaginatedResponse.create(
+                    items=items,
+                    total=total,
+                    page=pagination.page,
+                    limit=pagination.limit,
+                )
+
+            search_query = f"%{query.lower()}%"
+            if self.session:
+                count_result = await self.session.execute(
                     select(func.count(Item.id)).where(
                         func.lower(Item.name).like(search_query)
                     )
                 )
                 total = count_result.scalar()
-                
-                # Get paginated results
-                query_stmt = select(Item).where(
-                    func.lower(Item.name).like(search_query)
-                ).order_by(Item.created_at.desc())
-                
-                if pagination:
-                    query_stmt = query_stmt.offset(pagination.offset).limit(pagination.limit)
-                
-                result = await session.execute(query_stmt)
+
+                query_stmt = (
+                    select(Item)
+                    .where(func.lower(Item.name).like(search_query))
+                    .order_by(Item.created_at.desc())
+                    .offset(pagination.offset)
+                    .limit(pagination.limit)
+                )
+                result = await self.session.execute(query_stmt)
                 items = result.scalars().all()
-                
-                self.logger.debug(f"Found {len(items)} items matching query (total: {total})")
-                return list(items), total
-            
+            else:
+                async with db_manager.get_session() as session:
+                    count_result = await session.execute(
+                        select(func.count(Item.id)).where(
+                            func.lower(Item.name).like(search_query)
+                        )
+                    )
+                    total = count_result.scalar()
+
+                    query_stmt = (
+                        select(Item)
+                        .where(func.lower(Item.name).like(search_query))
+                        .order_by(Item.created_at.desc())
+                        .offset(pagination.offset)
+                        .limit(pagination.limit)
+                    )
+                    result = await session.execute(query_stmt)
+                    items = result.scalars().all()
+
+            self.logger.debug(f"Found {len(items)} items matching query (total: {total})")
+            return PaginatedResponse.create(
+                items=list(items),
+                total=total,
+                page=pagination.page,
+                limit=pagination.limit,
+            )
+
         except SQLAlchemyError as e:
             self.logger.error(f"Database error searching items: {e}")
             raise

--- a/app/services/item_service.py
+++ b/app/services/item_service.py
@@ -56,8 +56,8 @@ class ItemService:
             if pagination is None:
                 pagination = PaginationParams()
             
-            db_items, total = await self.item_repository.get_all(pagination)
-            
+            db_response = await self.item_repository.get_all(pagination)
+
             # Convert database models to Pydantic models
             items = [
                 Item(
@@ -66,16 +66,16 @@ class ItemService:
                     price=db_item.price,
                     is_offer=db_item.is_offer,
                     created_at=db_item.created_at,
-                    updated_at=db_item.updated_at
+                    updated_at=db_item.updated_at,
                 )
-                for db_item in db_items
+                for db_item in db_response.items
             ]
-            
+
             return PaginatedResponse.create(
                 items=items,
-                total=total,
-                page=pagination.page,
-                limit=pagination.limit
+                total=db_response.total,
+                page=db_response.page,
+                limit=db_response.limit,
             )
             
         except Exception as e:
@@ -190,8 +190,8 @@ class ItemService:
             if pagination is None:
                 pagination = PaginationParams()
             
-            db_items, total = await self.item_repository.search(query.strip(), pagination)
-            
+            db_response = await self.item_repository.search(query.strip(), pagination)
+
             # Convert database models to Pydantic models
             items = [
                 Item(
@@ -200,16 +200,16 @@ class ItemService:
                     price=db_item.price,
                     is_offer=db_item.is_offer,
                     created_at=db_item.created_at,
-                    updated_at=db_item.updated_at
+                    updated_at=db_item.updated_at,
                 )
-                for db_item in db_items
+                for db_item in db_response.items
             ]
-            
+
             return PaginatedResponse.create(
                 items=items,
-                total=total,
-                page=pagination.page,
-                limit=pagination.limit
+                total=db_response.total,
+                page=db_response.page,
+                limit=db_response.limit,
             )
             
         except Exception as e:


### PR DESCRIPTION
## Summary
- allow ItemRepository to accept an optional database session
- return `PaginatedResponse` from repository methods and update ItemService to use it

## Testing
- `pytest tests/test_main.py -q`
- `pytest -q` *(fails: httpx.ConnectError; AttributeError: 'MockSession' object has no attribute 'execute'; AssertionError: assert 13 == 10)*

------
https://chatgpt.com/codex/tasks/task_e_6896f44b65e88320a9060c15ccd70afd